### PR TITLE
Update buf plugin refefences

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -28,7 +28,7 @@ plugins:
     out: ./buf
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.1-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: ./openapi
     opt:
       - allow_merge=true

--- a/realtime/buf.gen.yaml
+++ b/realtime/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.1-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: ./realtime/private/service/openapi
     opt:
       - allow_merge=true

--- a/saas/buf.gen.yaml
+++ b/saas/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.1-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: ./saas/private/service/openapi
     opt:
       - allow_merge=true

--- a/sys/buf.gen.yaml
+++ b/sys/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.1-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: ./sys/private/service/openapi
     opt:
       - allow_merge=true

--- a/user/buf.gen.yaml
+++ b/user/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.1-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.2
     out: ./user/private/service/openapi
     opt:
       - allow_merge=true


### PR DESCRIPTION
Hey there, this PR updates the plugin references in buf.gen.yaml files based on the[upcoming Remote Package changes](https://buf.build/blog/remote-packages-remote-plugins-approaching-v1).

Note, I didn't generate any protos.

Many of the plugins can also be referenced similar to https://buf.build/grpc-ecosystem/openapiv2, e.g.,

- https://buf.build/bufbuild/validate-go
- https://buf.build/protocolbuffers/go
- https://buf.build/grpc/go